### PR TITLE
Fixes ruby 1.9.3 lambda sintax and updates spree_core requirement to 1.2.0

### DIFF
--- a/app/models/spree/banner.rb
+++ b/app/models/spree/banner.rb
@@ -5,11 +5,10 @@ module Spree
     has_attached_file :attachment,
                 :url  => "/spree/banner/:id/:style_:basename.:extension",
                 :path => ":rails_root/public/spree/banner/:id/:style_:basename.:extension",
-                #:default_url => "/missing/:style.jpg",
-                :styles => lambda {|a|
-                      :thumbnail => "80x80#",
-                      :custom => "#{a.instance.attachment_width}x#{a.instance.attachment_height}#"
-                },
+                :styles => ->(a) { 
+                              { :thumbnail => "80x80#",
+                                :custom => "#{a.instance.attachment_width}x#{a.instance.attachment_height}#" }
+                            },
                 :convert_options => {
                       :thumbnail => "-gravity center"
                 }

--- a/spree_banner.gemspec
+++ b/spree_banner.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_banner'
-  s.version     = '1.1.1'
+  s.version     = '1.2.0'
   s.summary     = 'Extension to manage banner for you Spree Shop'
   s.required_ruby_version = '>= 1.8.7'
 
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core'
+  s.add_dependency 'spree_core', '~> 1.2.0'
   
   s.add_dependency 'formtastic'
   s.add_dependency 'paperclip'


### PR DESCRIPTION
Don't exactly if is this the best approach but works.
